### PR TITLE
Fix nested HTML document structure in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,19 +3,7 @@ layout: page
 description: "Love, live and lost."
 ---
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="{{ page.description }}">
-    <title>{{ site.title }} - {{ page.description }}</title>
-
-    <!-- Optionally, include the theme (if you don't want to struggle to write the CSS) -->
-    <link rel="stylesheet" href="https://unpkg.com/github-calendar@latest/dist/github-calendar-responsive.css">
-
-    <!-- Custom styles for this template -->
-    <style>
+<style>
         .post-preview {
             margin-bottom: 2rem;
         }
@@ -138,8 +126,6 @@ description: "Love, live and lost."
 
 
     </style>
-</head>
-<body>
 
 
 
@@ -229,8 +215,3 @@ description: "Love, live and lost."
 </nav>
 {% endif %}
 
-<!-- Include the library -->
-<script src="https://unpkg.com/github-calendar@latest/dist/github-calendar.min.js" defer></script>
-
-</body>
-</html>


### PR DESCRIPTION
## Summary

- `index.html` used `layout: page` in its front matter but also contained a full `<!DOCTYPE html>…<body>…</body></html>` wrapper, causing Jekyll to embed a second HTML document inside `default.html`.
- This produced broken output with a nested `<!DOCTYPE html>` at line 274 of the built `_site/index.html`, breaking page rendering.

## Changes

- Removed redundant `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`, `</body>`, `</html>` tags from `index.html`
- Removed unused `github-calendar` CSS/JS imports (no calendar widget in the page)
- Kept the `<style>` block as inline content, correctly injected by Jekyll into the layout chain

## Test plan

- [ ] Build site locally with `bundle exec jekyll serve` and confirm no nested HTML in the output
- [ ] Verify home page renders correctly with blog post list, image gallery, and quote section

🤖 Generated with [Claude Code](https://claude.com/claude-code)